### PR TITLE
ADD gold layer transactions with merchant coordinates and is fraud cl…

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -23,6 +23,8 @@ models:
       +schema: staging
       +materialized: view
     intermediate:
+      + schema: intermediate
       +materialized: view
     marts:
+      + schema: mart
       +materialized: table

--- a/dbt/models/marts/cc_transactions/mart_transactions_with_merchant_coordinates.sql
+++ b/dbt/models/marts/cc_transactions/mart_transactions_with_merchant_coordinates.sql
@@ -1,0 +1,6 @@
+SELECT
+    transaction_number,
+    merchant_latitude,
+    merchant_longitude,
+    is_fraud
+FROM {{ ref('int_transactions_enriched') }}

--- a/dbt/models/marts/cc_transactions/mart_transactions_with_merchant_coordinates.yml
+++ b/dbt/models/marts/cc_transactions/mart_transactions_with_merchant_coordinates.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: mart_transactions_with_merchant_coordinates
+    description:  >
+       Latitude and longitude of all transactions and classification if it was a fraudulent transaction.
+    columns:
+      - name: transaction_number
+        description: "{{ doc('transaction_number') }}"
+        data_tests:
+          - unique
+          - not_null
+      - name: merchant_latitude
+        description: "{{ doc('merchant_latitude') }}"
+        data_tests:
+          - not_null
+      - name: merchant_longitude
+        description: "{{ doc('merchant_longitude') }}"
+        data_tests:
+          - not_null
+      - name: is_fraud
+        description: "{{ doc('is_fraud') }}"
+        data_tests:
+          - not_null


### PR DESCRIPTION
Adds fully documented and tested mart model for merchant coordinates (like latitude and longitude) and is fraud classification.

The output can be used by visualizations to like maps of these fraud cases or in general transactions.